### PR TITLE
Fixed callsign validator and added an option to omit Omnirig in Win32 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,11 +253,12 @@ if (WIN32)
     ${wsjt_CXXSRCS}
     killbyname.cpp
     )
-
+  if(NOT SKIP_OMNIRIG) 
   set (wsjt_qt_CXXSRCS
     ${wsjt_qt_CXXSRCS}
     OmniRigTransceiver.cpp
     )
+  endif(NOT SKIP_OMNIRIG)
 endif (WIN32)
 
 set (wsjt_FSRCS
@@ -441,7 +442,7 @@ endif (WSJT_QDEBUG_IN_RELEASE)
 set_property (SOURCE ${all_C_and_CXXSRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -include wsjtx_config.h")
 set_property (SOURCE ${all_C_and_CXXSRCS} APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/wsjtx_config.h)
 
-if (WIN32)
+if (WIN32 AND NOT SKIP_OMNIRIG)
   # generate the OmniRig COM interface source
   find_program (DUMPCPP dumpcpp)
   if (DUMPCPP-NOTFOUND)
@@ -458,7 +459,7 @@ if (WIN32)
   endif (NOT AXSERVER)
   string (REPLACE "\"" "" AXSERVER ${AXSERVER})
   file (TO_CMAKE_PATH ${AXSERVER} AXSERVERSRCS)
-endif (WIN32)
+endif (WIN32 AND NOT SKIP_OMNIRIG)
 
 
 #
@@ -522,10 +523,10 @@ message (STATUS "Hamlib_LIBRARIES: ${Hamlib_LIBRARIES}")
 #
 find_package(Qt6 6.4 REQUIRED COMPONENTS Widgets Multimedia SerialPort)
 
-if (WIN32)
+if (WIN32 AND NOT SKIP_OMNIRIG)
   add_definitions (-DQT_NEEDS_QTMAIN)
   find_package (Qt6 REQUIRED COMPONENTS AxContainer AxServer)
-endif (WIN32)
+endif (WIN32 AND NOT SKIP_OMNIRIG)
 
 
 #
@@ -749,10 +750,10 @@ qt6_wrap_ui (wsjtx_GENUISRCS ${wsjtx_UISRCS})
 qt6_add_resources (wsjtx_RESOURCES_RCC ${CMAKE_BINARY_DIR}/wsjtx.qrc)
 
 # AX COM servers
-if (WIN32)
+if (WIN32 AND NOT SKIP_OMNIRIG)
   include (QtAxMacros)
   wrap_ax_server (GENAXSRCS ${AXSERVERSRCS})
-endif (WIN32)
+endif (WIN32 AND NOT SKIP_OMNIRIG)
 
 
 #
@@ -795,9 +796,9 @@ add_library (wsjt_qt STATIC ${wsjt_qt_CXXSRCS} ${wsjt_qt_GENUISRCS} ${GENAXSRCS}
 # set wsjtx_udp exports to static variants
 target_compile_definitions (wsjt_qt PUBLIC UDP_STATIC_DEFINE)
 target_link_libraries (wsjt_qt Hamlib::Hamlib Qt6::Widgets Qt6::Network Qt6::SerialPort)
-if (WIN32)
+if (WIN32 AND NOT SKIP_OMNIRIG)
   target_link_libraries (wsjt_qt Qt6::AxContainer Qt6::AxServer)
-endif (WIN32)
+endif (WIN32 AND NOT SKIP_OMNIRIG)
 
 add_library (wsjt_qtmm STATIC ${wsjt_qtmm_CXXSRCS} ${wsjt_qtmm_GENUISRCS})
 target_link_libraries (wsjt_qtmm Qt6::Multimedia)

--- a/CallsignValidator.cpp
+++ b/CallsignValidator.cpp
@@ -2,15 +2,17 @@
 
 CallsignValidator::CallsignValidator (QObject * parent, bool allow_compound)
   : QValidator {parent}
-  , re_ {allow_compound ? R"(^[A-Za-z0-9/]+$)" : R"(^[A-Za-z0-9]+$)"}
+  , re_ {allow_compound ? 
+      R"(^(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)/)?([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d))))$)"
+      : R"(^([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"}
 {
 }
 
 auto CallsignValidator::validate (QString& input, int& pos) const -> State
 {
+  re_.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
   auto match = re_.match (input, 0, QRegularExpression::PartialPreferCompleteMatch);
   input = input.toUpper ();
-  if (input.count(QLatin1Char('/')) > 2) return Invalid;
   if (match.hasMatch ()) return Acceptable;
   if (!input.size () || match.hasPartialMatch ()) return Intermediate;
   pos = input.size ();

--- a/CallsignValidator.cpp
+++ b/CallsignValidator.cpp
@@ -5,13 +5,19 @@ CallsignValidator::CallsignValidator (QObject * parent, bool allow_compound)
   , re_ {allow_compound ? 
       R"(^(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)/)?([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d))))$)"
       : R"(^([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"}
+  , _pattern {
+    allow_compound ? 
+      "(^(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)/)?([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d))))$)"
+      : "(^([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"
+  }
 {
 }
 
 auto CallsignValidator::validate (QString& input, int& pos) const -> State
 {
-  re_.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
-  auto match = re_.match (input, 0, QRegularExpression::PartialPreferCompleteMatch);
+  QRegularExpression reCall = QRegularExpression( _pattern, QRegularExpression::CaseInsensitiveOption );
+  // re_.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
+  auto match = reCall.match (input, 0, QRegularExpression::PartialPreferCompleteMatch);
   input = input.toUpper ();
   if (match.hasMatch ()) return Acceptable;
   if (!input.size () || match.hasPartialMatch ()) return Intermediate;

--- a/CallsignValidator.cpp
+++ b/CallsignValidator.cpp
@@ -3,12 +3,12 @@
 CallsignValidator::CallsignValidator (QObject * parent, bool allow_compound)
   : QValidator {parent}
   , re_ {allow_compound ? 
-      R"(^(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)/)?([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d))))$)"
-      : R"(^([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"}
+      R"(^(([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d?/)?([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d?)))?$)"
+      : R"(^([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"}
   , _pattern {
     allow_compound ? 
-      "(^(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)/)?([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([A-Z]{2}|\\d[A-Z]|[A-Z]\\d))))$)"
-      : "(^([A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$)"
+      "^(([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d?/)?([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+(/(P|M|A|\\d|QRP|(([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d?)))?$"
+      : "^([BFGIKMNRUWDS]|[A-Z]{2}|\\d[A-Z]|[A-Z]\\d)\\d+[A-Z]+$"
   }
 {
 }

--- a/CallsignValidator.hpp
+++ b/CallsignValidator.hpp
@@ -18,6 +18,7 @@ public:
 
 private:
   QRegularExpression re_;
+  QString _pattern ;
 };
 
 #endif

--- a/TransceiverFactory.cpp
+++ b/TransceiverFactory.cpp
@@ -7,7 +7,7 @@
 #include "HRDTransceiver.hpp"
 #include "EmulateSplitTransceiver.hpp"
 
-#if defined (WIN32)
+#if defined (WIN32) && defined(OMNIRIG)
 #include "OmniRigTransceiver.hpp"
 #endif
 
@@ -37,7 +37,7 @@ TransceiverFactory::TransceiverFactory ()
   DXLabSuiteCommanderTransceiver::register_transceivers (&transceivers_, CommanderId);
   HRDTransceiver::register_transceivers (&transceivers_, HRDId);
   
-#if defined (WIN32)
+#if defined (WIN32) && defined( OMNIRIG )
   // OmniRig is ActiveX/COM server so only on Windows
   OmniRigTransceiver::register_transceivers (&transceivers_, OmniRigOneId, OmniRigTwoId);
 #endif
@@ -129,7 +129,7 @@ std::unique_ptr<Transceiver> TransceiverFactory::create (ParameterPack const& pa
       }
       break;
 
-#if defined (WIN32)
+#if defined (WIN32) && defined( OMNIRIG )
     case OmniRigOneId:
       {
         std::unique_ptr<TransceiverBase> basic_transceiver;


### PR DESCRIPTION
Modified CallsignValidator to do real validation of amateur radio callsign. Prefixes as 1- or 2-char prefix followed by at least one digit followed by at least one letter. When allow_compound is true, additional CEPT prefix with or without number is also possible including unofficial prefixes like D1, S0, and suffix modifiers /P, /M, /A, /1 and /<country prefix>.
The new regexp is not fully restrictive but it will not allow most nonsense-like "callsigns" decoded by JS8 sometimes when signal is too weak, as seen in my monitoring during the last few months.
In the same commit (sorry) I added a few changes in CMakeLists.txt to have option to avoid compilation of Omnirig related files in Windows. Omnirig seems to be long out of date, most likely not necessary even in Windows build of the application and so using -D SKIP_OMNIRIG=1 in CMake command line will prevent error message if Omnirig is not present on the host system.
